### PR TITLE
Add Truple DNS filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To start clone the repo:
 git clone https://github.com/plujon/filters
 cd filters
 ```
-To change information about a filter, edit the data.yml file. Once you make your changes, run `erb -T - index.html.erb >index.html` to update the index.html file.
+To change information about a filter, edit the data.yml file. Once you make your changes, run `erb -T - index.erb >index.html` to update the index.html file.
 
 
 ## Contact me

--- a/data.yml
+++ b/data.yml
@@ -2509,6 +2509,14 @@
   features: accountability filtering screenshots
   icon: https://truple.io/img/logo_small.png
   description: Truple captures screenshots at random times.
+- name: Truple DNS
+  url: https://play.google.com/store/apps/details?id=com.camhart.pornblocker
+  platform: android
+  audience: addict
+  cost: "free or $5 / month"
+  features: applock changedelay dns filtering
+  icon:
+  description: Not to be confused with the main Truple filter, which takes screenshots as well as providing filtering. You can lock the filter either with a delay or with a pin, but either way requires premium ($5 / month). App blocking also requires premium.
 - name: Trustwave SecureBrowsing
   url: https://www.trustwave.com/Products/SecureBrowsing/
   platform: browser

--- a/feature-legend.erb
+++ b/feature-legend.erb
@@ -10,7 +10,7 @@
       <dt id="antivirus">antivirus</dt> <dd>The software is part of an antivirus product.  Most antivirus products come with some type of parental controls.</dd>
       <dt id="applock">applock</dt> <dd>The software can block user access to programs.  See also games.</dd>
       <dt id="biglist">biglist</dt> <dd>Filtering is accomplished through a large database of categorized resources.</dd>
-      <dt id="changedelay">changedelay</dt> <dd>The software allows the end-user to configure it without a password, but will not allow the change to take effect for some amount of time.  The author knows of no filter that supports this other than Pluckeye.</dd>
+      <dt id="changedelay">changedelay</dt> <dd>The software allows the end-user to configure it without a password, but will not allow the change to take effect for some amount of time.  The author knows of only one filter that supports this (Truple DNS) other than Pluckeye.</dd>
       <dt id="cloud">cloud</dt> <dd>The software interacts with data in the cloud.  E.g., a list of websites to block are retrieved from a remote server.</dd>
       <dt id="counseling">counseling</dt> <dd>The software helps connect the user to a real-life counselor.</dd>
       <dt id="countermeasures">countermeasures</dt> <dd>The software will notice and respond to attempts to work around it.  E.g., k9 can be configured to block all Internet access for a specified time if too many attempts to visit blocked pages are detected.</dd>

--- a/index.html
+++ b/index.html
@@ -2420,6 +2420,20 @@
         <tr>
           <td>
             
+              <a href="https://play.google.com/store/apps/details?id=com.camhart.pornblocker" title="Truple DNS">
+            Truple DNS
+          </a>
+            
+          </td>
+          <td>free or $5 / month</td>
+          <td>android</td>
+          <td>addict</td>
+          <td>applock, changedelay, filtering</td>
+          <td>Not to be confused with the main Truple filter, which takes screenshots as well as providing filtering. You can lock the filter either with a delay or with a pin, but either way requires premium ($5 / month). App blocking also requires premium.</td>
+        </tr>
+        <tr>
+          <td>
+            
               <a href="https://www.trustwave.com/Products/SecureBrowsing/" title="Trustwave SecureBrowsing">
             Trustwave SecureBrowsing
           </a>
@@ -3115,7 +3129,7 @@
       <dt id="antivirus">antivirus</dt> <dd>The software is part of an antivirus product.  Most antivirus products come with some type of parental controls.</dd>
       <dt id="applock">applock</dt> <dd>The software can block user access to programs.  See also games.</dd>
       <dt id="biglist">biglist</dt> <dd>Filtering is accomplished through a large database of categorized resources.</dd>
-      <dt id="changedelay">changedelay</dt> <dd>The software allows the end-user to configure it without a password, but will not allow the change to take effect for some amount of time.  The author knows of no filter that supports this other than Pluckeye.</dd>
+      <dt id="changedelay">changedelay</dt> <dd>The software allows the end-user to configure it without a password, but will not allow the change to take effect for some amount of time.  The author knows of only one filter that supports this (Truple DNS) other than Pluckeye.</dd>
       <dt id="cloud">cloud</dt> <dd>The software interacts with data in the cloud.  E.g., a list of websites to block are retrieved from a remote server.</dd>
       <dt id="counseling">counseling</dt> <dd>The software helps connect the user to a real-life counselor.</dd>
       <dt id="countermeasures">countermeasures</dt> <dd>The software will notice and respond to attempts to work around it.  E.g., k9 can be configured to block all Internet access for a specified time if too many attempts to visit blocked pages are detected.</dd>


### PR DESCRIPTION
Truple has a DNS-based filter in the Google Play store as well as their main screenshot-based program.